### PR TITLE
Update hast-util-is-element to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "index.js"
   ],
   "dependencies": {
-    "hast-util-is-element": "^1.0.0",
+    "hast-util-is-element": "^1.1.0",
     "repeat-string": "^1.0.0",
     "unist-util-find-after": "^3.0.0"
   },


### PR DESCRIPTION
The latest version of hast-util-to-text requires the module `hast-util-is-element/convert`, which is only available in hast-util-is-element 1.1.0. In one of my projects, I got the error message `Cannot find module 'hast-util-is-element/convert'`. I looked into my `node_modules` folder and noticed that only hast-util-is-element 1.0.0 was installed. I think another library requires hast-util-is-element 1.0.0 and npm did therefore not download the latest version. I was able to resolve this issue manually by running `npm i hast-util-is-element@latest` but I think it would be better to fix the dependency here.