### PR TITLE
Fix `li` elements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,6 +106,7 @@ const blockOrCaption = convertElement([
   'hr', // Flow content
   'html', // Page
   'legend', // Flow content
+  'li', // Lists
   'listing', // Flow content (legacy)
   'main', // Flow content
   'menu', // Lists

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,7 @@ const blockOrCaption = convertElement([
   'hr', // Flow content
   'html', // Page
   'legend', // Flow content
-  'li', // Lists
+  'li', // Lists (as `display: list-item`)
   'listing', // Flow content (legacy)
   'main', // Flow content
   'menu', // Lists

--- a/test.js
+++ b/test.js
@@ -358,6 +358,13 @@ test('non-normal white-space', async function (t) {
       '\tDelta \n\techo\t\n'
     )
   })
+
+  await t.test('should support `li` elements', async function () {
+    assert.equal(
+      toText(h('ul', [h('li', 'Foxtrot'), h('li', 'Golf')])),
+      'Foxtrot\nGolf'
+    )
+  })
 })
 
 test('more whitespace', async function (t) {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Currently, `li` elements are not interpreted as blocks, so `ul` and `ol` elements get parsed into a single line of text.

```js
toText(h('ul', [h('li', 'Foxtrot'), h('li', 'Golf')]))
``` 

Running the above yields `'FoxtrotGolf'` instead of `'Foxtrot\nGolf'`. 

This PR enables the expected behaviour.

<!--do not edit: pr-->
